### PR TITLE
Support queries that span multiple tables

### DIFF
--- a/src/mnshankar/CSV/CSV.php
+++ b/src/mnshankar/CSV/CSV.php
@@ -87,11 +87,11 @@ class CSV
         foreach ($this->source as $key => $row) {
             if ($this->headerRowExists) {
                 if (empty($header)) { // output header once!
-                    $header = array_keys($row);
+                    $header = array_keys(array_dot($row));
                     fputcsv($this->handle, $header, $this->delimiter, $this->enclosure); // put them in csv
                 }
             }
-            fputcsv($this->handle, $row, $this->delimiter, $this->enclosure);
+            fputcsv($this->handle, array_dot($row), $this->delimiter, $this->enclosure);
         }               
     }
     public function toString()


### PR DESCRIPTION
Selecting a model and connected tables would throw an 'Array to string
conversion' error and fail to process the download. Converting the array
keys into a dot notation (using array_dot) and then flattening the row,
again, using array_dot, allows such queries to work.
