### PR TITLE
Improved multilevel array exports

### DIFF
--- a/src/mnshankar/CSV/CSV.php
+++ b/src/mnshankar/CSV/CSV.php
@@ -84,13 +84,13 @@ class CSV
     }    
     public function getCSV()
     {
-        foreach ($this->source as $key => $row) {
             if ($this->headerRowExists) {
-                if (empty($header)) { // output header once!
-                    $header = array_keys(array_dot($row));
-                    fputcsv($this->handle, $header, $this->delimiter, $this->enclosure); // put them in csv
-                }
+            $longest_row = max($this->source);
+            $header = array_keys(array_dot($longest_row));
+            fputcsv($this->handle, $header, $this->delimiter, $this->enclosure);
             }
+
+        foreach ($this->source as $key => $row) {
             fputcsv($this->handle, array_dot($row), $this->delimiter, $this->enclosure);
         }               
     }

--- a/tests/CSVTest.php
+++ b/tests/CSVTest.php
@@ -47,4 +47,59 @@ name1,address1
 name2,address2
 ');
     }
+
+    public function testMultiArrayFlattens()
+    {
+        $obj = new CSV();
+        $arr = array(
+            array(
+                'title' => 'Hello world',
+                'comments' => array(
+                    array('title' => 'First'),
+                    array('title' => 'Second'),
+                ),
+            )
+        );
+
+        $flattened_data = <<<EOL
+title,comments.0.title,comments.1.title
+"Hello world",First,Second
+
+EOL;
+
+        $data = $obj->with($arr)->setFileHandle()->toString();
+        $this->assertEquals($data, $flattened_data);
+    }
+
+    public function testMultiArrayFlattensDifferetLengthRows()
+    {
+        $obj = new CSV();
+        $arr = array(
+            array(
+                'title' => 'Hello world',
+                'comments' => array(
+                    array('title' => 'First'),
+                    array('title' => 'Second'),
+                ),
+            ),
+            array(
+                'title' => 'Hello world, again',
+                'comments' => array(
+                    array('title' => 'First'),
+                    array('title' => 'Second'),
+                    array('title' => 'Third'),
+                ),
+            )
+        );
+
+        $flattened_data = <<<EOL
+title,comments.0.title,comments.1.title,comments.2.title
+"Hello world",First,Second
+"Hello world, again",First,Second,Third
+
+EOL;
+
+        $data = $obj->with($arr)->setFileHandle()->toString();
+        $this->assertEquals($data, $flattened_data);
+    }
 }


### PR DESCRIPTION
With multidimensional arrays it's possible to have the longest array anywhere within the source. Searching for the longest record and using that will mean that all entries will have the correct headings.

Previously just the first row was used to get the headers, but if a subsequent row had, e.g. more comments, then these rows wouldn't have a header column to match up with.

This also include some new test cases for multidimensional arrays.
