### PR TITLE
Laravel 4.2 compatibility.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "illuminate/support": ">=4.1.*"
+        "illuminate/support": ">=4.1.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Hello,

With Laravel 4.2 on the horizon this package needs an updated `composer.json`. Laravel 4.2 does not include any breaks for this library, so it was a simple version string change.

Cheers,
-Andrew
