### PR TITLE
Updating CSV.php to add a string specifying the delimiter of the file

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,11 +24,12 @@ $arr = array(
     array('col1'=>'1','col2'=>'2'),
     array('col1'=>'3','col2'=>'4'),
 );
-return $csvObj->fromArray($arr)->render('myfile.csv'); //download as csv
-return $csvObj->with($arr)->put('/downloads/myusers.csv');	//store as csv in this path
-return $csvObj->fromFile('/downloads/my.csv')->toArray();    //return csv file as an array
-return $csvObj->fromFile('/downloads/my.csv')->render('abc.csv'); //render saved csv file as a downloadable document
-return $csvObj->with('/downloads/my.csv')->render('abc.csv'); //use 'with'.. same as previous
+return $csvObj->fromArray($arr)->render('myfile.csv');                  //download as csv;
+return $csvObj->fromArray($arr)->withSeparator()->render('myfile.csv'); //add delimiter for better excel compatibility & download
+return $csvObj->with($arr)->put('/downloads/myusers.csv');	            //store as csv in this path
+return $csvObj->fromFile('/downloads/my.csv')->toArray();               //return csv file as an array
+return $csvObj->fromFile('/downloads/my.csv')->render('abc.csv');       //render saved csv file as a downloadable document
+return $csvObj->with('/downloads/my.csv')->render('abc.csv');           //use 'with'.. same as previous
 ```
 
 ##Laravel 4

--- a/src/mnshankar/CSV/CSV.php
+++ b/src/mnshankar/CSV/CSV.php
@@ -8,6 +8,7 @@ class CSV
     protected $headerRowExists = true;
     protected $delimiter = ',';
     protected $enclosure = '"';
+    protected $withSeparator = false;
 
     public function setDelimiter($delimiter)
     {
@@ -42,6 +43,16 @@ class CSV
             }
         }
 
+        return $this;
+    }
+
+    /**
+     * Sets the $withSeparator property to true to specify the delimiter in the file
+     * @return $this
+     */
+    public function withSeparator()
+    {
+        $this->withSeparator = true;
         return $this;
     }
 
@@ -91,7 +102,13 @@ class CSV
         header('Cache-Control: private');
         header('pragma: cache');
 
-        echo $this->toString();
+        $response = $this->toString();
+
+        if( $this->withSeparator ){
+            $response = 'sep='.$this->delimiter.PHP_EOL.$response;
+        }
+
+        echo $response;
         exit;
     }
 


### PR DESCRIPTION
Added the `$withSeparator` property to allow users to add the separator string in the CSV file; this way Excel will better read the file and interpret the data. No more selecting the data and running "_Text to columns_" wizard.
